### PR TITLE
Add a checkmk monitor logger handler

### DIFF
--- a/pytroll_monitor/checkmk_logger.py
+++ b/pytroll_monitor/checkmk_logger.py
@@ -63,7 +63,6 @@ class CheckMKHandler(logging.Handler):
 
     def emit(self, record):
         """Emit a record."""
-        pass
 
     def get_status_line(self):
         """Get the checkmk status line.

--- a/pytroll_monitor/checkmk_logger.py
+++ b/pytroll_monitor/checkmk_logger.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2021
+
+# Author(s):
+
+#   Gerrit Holl <gerrit.holl@dwd.de>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Logger to report status to checkmk local checks
+
+This module contains a logging handler that will gather information based on
+logging messages and report the status to a checkmk local check file.
+
+For more information on checkmk local checks, see
+https://docs.checkmk.com/latest/en/localchecks.html
+"""
+
+import logging
+
+from enum import IntEnum
+
+
+class ServiceStatus(IntEnum):
+    """Service status according to checkmk local checks.
+
+    Enumerate the service status according to checkmk local checks.
+    """
+    OK = 0
+    WARN = 1
+    CRIT = 2
+    UNKNOWN = 3
+
+
+class CheckMKHandler(logging.Handler):
+    """Handler to report checkmk local check."""
+
+    service_name = '"Pytroll status report"'
+
+    def __init__(self, status_file):
+        """Initialise the logger.
+
+        The status_file should be the file where checkmk will check the status.
+        """
+        super().__init__()
+        self.status_file = status_file
+        self.status = ServiceStatus.UNKNOWN
+        self.write_status_to_file()
+
+    def emit(self, record):
+        """Emit a record."""
+        pass
+
+    def get_status_line(self):
+        """Get the checkmk status line.
+
+        Format is defined at
+        https://docs.checkmk.com/latest/en/localchecks.html
+        """
+        return f"{ServiceStatus.UNKNOWN:d} {self.service_name:s} - Pytroll lives!"
+
+    def write_status_to_file(self):
+        """Update the status in the status file."""
+        status_line = self.get_status_line()
+        with open(self.status_file, "wt", encoding="ascii") as fp:
+            fp.write(status_line)

--- a/pytroll_monitor/checkmk_logger.py
+++ b/pytroll_monitor/checkmk_logger.py
@@ -49,7 +49,7 @@ An example logging config illustrating how to use this::
         formatter: pytroll
         stream: ext://sys.stdout
       monitor:
-        (): pytroll_monitor.checkmk_logger.CheckMKHandler
+        (): pytroll_monitor.checkmk_logger.Trollflow2CheckMKHandler
         level: DEBUG
         formatter: pytroll
         status_file: /opt/pytroll/pytroll_inst/pytroll_status
@@ -82,8 +82,8 @@ class ServiceStatus(IntEnum):
     UNKNOWN = 3
 
 
-class CheckMKHandler(logging.Handler):
-    """Handler to report checkmk local check.
+class Trollflow2CheckMKHandler(logging.Handler):
+    """Handler to report checkmk local for use with trollflow2.
 
     This handler abuses logging messages for a status report.  If any message
     is logged with level WARNING, it will set a checkmk status to WARN.  If any

--- a/pytroll_monitor/checkmk_logger.py
+++ b/pytroll_monitor/checkmk_logger.py
@@ -23,10 +23,46 @@
 """Logger to report status to checkmk local checks.
 
 This module contains a logging handler that will gather information based on
-logging messages and report the status to a checkmk local check file.
+logging messages and report the status to a checkmk local check file.  It is
+still a work in progress.  So far it just writes a single line to the indicated
+status_line, and the only thing that changes is the initial digit, where 0 =
+OK, 1 = WARN, 2 = CRIT, and 3 = UNKNOWN.  Status starts at unknown.  When a
+message is logged with level warn, status is set to warn.  When a message is
+logged with level error or critical, status is set to critical.  When the
+message "All n files produced nominally" for n>0 is logged, status is set to
+OK.
 
 For more information on checkmk local checks, see
 https://docs.checkmk.com/latest/en/localchecks.html
+
+An example logging config illustrating how to use this::
+
+    version: 1
+    disable_existing_loggers: false
+    formatters:
+      pytroll:
+        format: '[%(asctime)s %(levelname)-8s %(name)s] %(message)s'
+    handlers:
+      console:
+        class: logging.StreamHandler
+        level: DEBUG
+        formatter: pytroll
+        stream: ext://sys.stdout
+      monitor:
+        (): pytroll_monitor.checkmk_logger.CheckMKHandler
+        level: DEBUG
+        formatter: pytroll
+        status_file: /opt/pytroll/pytroll_inst/pytroll_status
+    root:
+      level: DEBUG
+      handlers:
+        - console
+        - monitor
+
+Pass this to the logging config option for supported pytroll packages,
+such as::
+
+    satpy_launcher.py -n localhost trollflow2.yaml -c logging.yaml
 """
 
 import logging

--- a/pytroll_monitor/checkmk_logger.py
+++ b/pytroll_monitor/checkmk_logger.py
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Logger to report status to checkmk local checks
+"""Logger to report status to checkmk local checks.
 
 This module contains a logging handler that will gather information based on
 logging messages and report the status to a checkmk local check file.
@@ -39,6 +39,7 @@ class ServiceStatus(IntEnum):
 
     Enumerate the service status according to checkmk local checks.
     """
+
     OK = 0
     WARN = 1
     CRIT = 2
@@ -70,7 +71,8 @@ class CheckMKHandler(logging.Handler):
         Format is defined at
         https://docs.checkmk.com/latest/en/localchecks.html
         """
-        return f"{ServiceStatus.UNKNOWN:d} {self.service_name:s} - Pytroll lives!"
+        return (f"{ServiceStatus.UNKNOWN:d} {self.service_name:s} "
+                "- Pytroll lives!")
 
     def write_status_to_file(self):
         """Update the status in the status file."""

--- a/pytroll_monitor/tests/test_loggers.py
+++ b/pytroll_monitor/tests/test_loggers.py
@@ -1,0 +1,11 @@
+import os
+def test_checkmk_handler(tmp_path):
+    from pytroll_monitor.checkmk_logger import CheckMKHandler
+    f = tmp_path / "bla"
+    handler = CheckMKHandler(os.fspath(f))
+    status = handler.get_status_line()
+    assert status == '3 "Pytroll status report" - Pytroll lives!'
+    with f.open(mode="rt", encoding="ascii") as fp:
+        contents = fp.read()
+        assert contents == status
+    handler.emit(None)

--- a/pytroll_monitor/tests/test_loggers.py
+++ b/pytroll_monitor/tests/test_loggers.py
@@ -49,7 +49,7 @@ def test_checkmk_handler(tmp_path):
 
         # log something good
         logger.info("All 100 files produced nominally in 00:00:00")
-        assert ch.get_status_line().startswith("0 ")  # 0 for OK, resets warnings
+        assert ch.get_status_line().startswith("0 ")  # 0 for OK
 
         # check that this is in the file, too
         with f.open(mode="rt", encoding="ascii") as fp:

--- a/pytroll_monitor/tests/test_loggers.py
+++ b/pytroll_monitor/tests/test_loggers.py
@@ -1,11 +1,40 @@
+"""Tests for custom logging handlers."""
 import os
+import logging
+
+
 def test_checkmk_handler(tmp_path):
+    """Test functionality for checkmk log handler."""
     from pytroll_monitor.checkmk_logger import CheckMKHandler
     f = tmp_path / "bla"
-    handler = CheckMKHandler(os.fspath(f))
-    status = handler.get_status_line()
-    assert status == '3 "Pytroll status report" - Pytroll lives!'
-    with f.open(mode="rt", encoding="ascii") as fp:
-        contents = fp.read()
-        assert contents == status
-    handler.emit(None)
+    ch = CheckMKHandler(os.fspath(f))
+    logger = logging.getLogger("pytroll.test")
+    ch.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(
+            "{asctime:s} - {name:s} - {levelname:s} - {message:s}",
+            style="{", validate=True)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    try:
+        # status is unknown, nothing logged yet
+        status = ch.get_status_line()
+        assert status == '3 "Pytroll status report" - Pytroll lives!'
+        with f.open(mode="rt", encoding="ascii") as fp:
+            contents = fp.read()
+            assert contents == status
+
+        # log something uninformative
+        logger.debug("No sono spaghetto")
+        assert ch.get_status_line() == ('3 "Pytroll status report" - '
+                                        "Pytroll lives!")
+
+        # log something problematic
+        logger.warning("You stepped on my toe!")
+        assert ch.get_status_line().startswith("1 ")  # 1 for warning
+
+        # log something critical
+        logger.critical("We're out of chocolate, coffee, and beer.")
+        assert ch.get_status_line().startswith("2 ")  # 2 for critical
+    finally:
+        logger.removeHandler(ch)

--- a/pytroll_monitor/tests/test_loggers.py
+++ b/pytroll_monitor/tests/test_loggers.py
@@ -9,6 +9,7 @@ def test_checkmk_handler(tmp_path):
     f = tmp_path / "bla"
     ch = CheckMKHandler(os.fspath(f))
     logger = logging.getLogger("pytroll.test")
+    logger.setLevel(logging.DEBUG)
     ch.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
             "{asctime:s} - {name:s} - {levelname:s} - {message:s}",
@@ -26,6 +27,7 @@ def test_checkmk_handler(tmp_path):
 
         # log something uninformative
         logger.debug("No sono spaghetto")
+        assert ch.get_status_line().startswith("3 ")  # 3 for unknown
         assert ch.get_status_line() == ('3 "Pytroll status report" - '
                                         "Pytroll lives!")
 
@@ -33,8 +35,26 @@ def test_checkmk_handler(tmp_path):
         logger.warning("You stepped on my toe!")
         assert ch.get_status_line().startswith("1 ")  # 1 for warning
 
+        # log something bad
+        logger.error("Lunch will be late")
+        assert ch.get_status_line().startswith("2 ")  # 2 for critical
+
         # log something critical
         logger.critical("We're out of chocolate, coffee, and beer.")
         assert ch.get_status_line().startswith("2 ")  # 2 for critical
+
+        # log something not so good
+        logger.info("All 0 files produced nominally in 00:00:00")
+        assert ch.get_status_line().startswith("1 ")  # 1 for warning
+
+        # log something good
+        logger.info("All 100 files produced nominally in 00:00:00")
+        assert ch.get_status_line().startswith("0 ")  # 0 for OK, resets warnings
+
+        # check that this is in the file, too
+        with f.open(mode="rt", encoding="ascii") as fp:
+            contents = fp.read(1)
+            assert contents == "0"
+
     finally:
         logger.removeHandler(ch)


### PR DESCRIPTION
Add a logging handler to report status for checkmk local status.

This PR adds a logging handler that infers from live logging the status of the pytroll operation and writes this status to a file.  This is currently limited to a single type of qualitative check, in which the monitor writes a single-line status file in the [checkmk local checks format](https://docs.checkmk.com/latest/en/localchecks.html).  The only part that changes is the status in the initial digit:

- When pytroll starts, the status is set to 3 (UNKNOWN)
- When a message is logged at WARNING level, status is set to 1 (WARN)
- When a message is logged at ERROR or CRITICAL level, status is set to 2 (CRITICAL)
- When a message is logged at INFO level containing "files produced nominally", status is set to 0 (OK)
- When a message is logged at INFO level containing "all 0 files produced nominally", status is set to 1 (WARN)

The user configures where this status is written to.

I've added unit tests, which increases the test coverage for pytroll-monitor from 0% to 31%.
