### PR TITLE
Fix name of CheckMKLogger in unit test

### DIFF
--- a/pytroll_monitor/tests/test_loggers.py
+++ b/pytroll_monitor/tests/test_loggers.py
@@ -5,9 +5,9 @@ import logging
 
 def test_checkmk_handler(tmp_path):
     """Test functionality for checkmk log handler."""
-    from pytroll_monitor.checkmk_logger import CheckMKHandler
+    from pytroll_monitor.checkmk_logger import Trollflow2CheckMKHandler
     f = tmp_path / "bla"
-    ch = CheckMKHandler(os.fspath(f))
+    ch = Trollflow2CheckMKHandler(os.fspath(f))
     logger = logging.getLogger("pytroll.test")
     logger.setLevel(logging.DEBUG)
     ch.setLevel(logging.DEBUG)


### PR DESCRIPTION
Fix the name of the class of the CheckMKLogger in the unit test.