### PR TITLE
Fix op5 to use GET, not POST

### DIFF
--- a/pytroll_monitor/monitor_hook.py
+++ b/pytroll_monitor/monitor_hook.py
@@ -76,8 +76,8 @@ class OP5Monitor(object):
                      "service_description": self.monitor_service,
                      "status_code": status,
                      "plugin_output": msg}
-        with requests.post(self.monitor_server,
-                           auth=self.monitor_auth,
-                           json=json_data) as response:
+        with requests.get(self.monitor_server,
+                          auth=self.monitor_auth,
+                          json=json_data) as response:
             response.raise_for_status()
             return response

--- a/pytroll_monitor/tests/test_op5.py
+++ b/pytroll_monitor/tests/test_op5.py
@@ -51,7 +51,7 @@ class TestOp5Interfaces:
         op5m = OP5Monitor(self.service, self.server, self.host, monitor_auth=None)
 
         with requests_mock.Mocker() as m:
-            m.post(self.server, text=self.response_text)
+            m.get(self.server, text=self.response_text)
             op5m.send_message(self.status, self.message)
             assert m.last_request.json() == self.expected_json
             assert m.last_request.url == self.server
@@ -63,7 +63,7 @@ class TestOp5Interfaces:
         op5m = OP5Monitor(self.service, self.server, self.host, self.auth)
 
         with requests_mock.Mocker() as m:
-            m.post(self.server, text=self.response_text)
+            m.get(self.server, text=self.response_text)
             op5m.send_message(self.status, self.message)
             assert m.last_request.headers["Authorization"] == self.expected_auth
 
@@ -74,7 +74,7 @@ class TestOp5Interfaces:
         logging.config.dictConfig(log_dict)
 
         with requests_mock.Mocker() as m:
-            m.post(self.server, text=self.response_text)
+            m.get(self.server, text=self.response_text)
             logger.warning(self.message)
             assert m.last_request.json() == self.expected_json
             assert m.last_request.headers["Authorization"] == self.expected_auth

--- a/pytroll_monitor/tests/test_op5.py
+++ b/pytroll_monitor/tests/test_op5.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pytroll_monitor.monitor_hook import OP5Monitor
-from pytroll_monitor.op5_logger import OP5Handler
-import yaml
 import logging
 import logging.config
-import requests_mock
 
+import requests_mock
+import yaml
+
+from pytroll_monitor.monitor_hook import OP5Monitor
+from pytroll_monitor.op5_logger import OP5Handler  # noqa
 
 yaml_config = """version: 1
 disable_existing_loggers: false
@@ -54,7 +55,7 @@ class TestOp5Interfaces:
             op5m.send_message(self.status, self.message)
             assert m.last_request.json() == self.expected_json
             assert m.last_request.url == self.server
-            assert m.last_request.method == "POST"
+            assert m.last_request.method == "GET"
             assert "Authorization" not in m.last_request.headers
 
     def test_op5monitor_with_auth(self):


### PR DESCRIPTION
This fixes the op5 monitor's wrongful use of POST